### PR TITLE
bug: ✨ #44 Warで勝利したときの返金額を修正する

### DIFF
--- a/games/war/scenes/PlayScene.ts
+++ b/games/war/scenes/PlayScene.ts
@@ -207,13 +207,12 @@ export default class PlayScene extends Table {
 
   payOut(result: GameResult) {
     if (this.betScene && this.betScene.money) {
-      if (
-        result === GameResult.WIN ||
-        result === GameResult.WAR_TIE
-      ) {
+      if (result === GameResult.WAR_TIE) {
         this.betScene.money += this.betScene.bet * 2;
       } else if (result === GameResult.WAR_WIN) {
         this.betScene.money += this.betScene.bet * 1.5; // 最初の賭金は返却、追加分は2倍の配当
+      } else if (result === GameResult.WIN) {
+        this.betScene.money += this.betScene.bet;
       } else if (result === GameResult.SURRENDER) {
         this.betScene.money -= this.betScene.bet * 0.5;
       } else {


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
#44 

# 変更内容
Warで勝利した場合の返金額をBet金額の2倍から1倍に変更した

# 影響範囲
他のゲームには影響しない

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
