### PR TITLE
feat: :sparkles: チップの移動アニメーションを追加する

### DIFF
--- a/games/common/Factories/button.ts
+++ b/games/common/Factories/button.ts
@@ -108,6 +108,19 @@ export default class Button extends Phaser.GameObjects
     });
   }
 
+  playMoveAndDestroy(toX: number, toY: number): void {
+    this.scene.tweens.add({
+      targets: this,
+      x: toX,
+      y: toY,
+      duration: MOVE_TIME,
+      ease: 'Linear',
+      onComplete: () => {
+        this.destroy();
+      }
+    });
+  }
+
   playFadeOut(): void {
     this.scene.tweens.add({
       targets: [this, this.#text],

--- a/games/common/scenes/BetScene.ts
+++ b/games/common/scenes/BetScene.ts
@@ -24,6 +24,8 @@ export default class BetScene extends BaseScene {
 
   public highScore: number | undefined;
 
+  #chips: Array<Button> = [];
+
   #dealButton: Button | undefined;
 
   #clearButton: Button | undefined;
@@ -181,20 +183,39 @@ export default class BetScene extends BaseScene {
       100
     );
 
-    const chips: Button[] = new Array<Button>();
-    chips.push(whiteChip);
-    chips.push(redChip);
-    chips.push(orangeChip);
-    chips.push(blueChip);
+    this.#chips.push(whiteChip);
+    this.#chips.push(redChip);
+    this.#chips.push(orangeChip);
+    this.#chips.push(blueChip);
 
     ImageUtility.spaceOutImagesEvenlyHorizontally(
-      chips as Button[],
+      this.#chips as Button[],
       this.scene
     );
-    chips.forEach((chip) => {
+
+    this.#chips.forEach((chip: Button) => {
       chip.setClickHandler(() => {
-        this.addChip(chip.getChipValue());
-        this.#dealButton?.playFadeIn();
+        if (this.bet + chip.getChipValue() <= this.money) {
+          this.addChip(chip.getChipValue());
+          this.#dealButton?.playFadeIn();
+          // アニメーション用のチップを作成する
+          const tempChip = new Button(
+            this,
+            chip.x,
+            chip.y,
+            chip.texture.key
+          );
+          tempChip.playMoveAndDestroy(this.config.width, 0);
+          // 現在のベット金額と追加チップの合計が所持金を上回る場合は、チップをフェードアウトする
+          this.#chips.forEach((otherChip: Button) => {
+            if (
+              this.bet + otherChip.getChipValue() >
+              this.money
+            ) {
+              otherChip.playFadeOut();
+            }
+          });
+        }
       });
     });
   }
@@ -233,6 +254,9 @@ export default class BetScene extends BaseScene {
       this.bet = 0;
       this.setBetText(this.bet);
       this.#dealButton?.playFadeOut();
+      this.#chips.forEach((chip) => {
+        chip.playFadeIn();
+      });
     });
   }
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
#80 

# 変更内容
BetSceneでチップをクリックしたときに、BetTextに向かってチップが移動するアニメーションを追加した。また、ベット金額、所持金、チップの金額を比べて、これ以上ベットできない場合に、チップをフェードアウトするアニメーションを追加した。

# 影響範囲
他のゲームへの影響はない。

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
