### PR TITLE
fix: 🐛 #83 開発中のゲームのカードを削除する

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,7 +51,7 @@ const Home = () => (
             imgPath="/images/thumbnailSample.png"
             ruleUrl="/rules/poker"
           />
-          <Card
+          {/* <Card
             title="Texas Hold'em Porker"
             description="世界的に大流行のポーカーゲーム。自分の手札は2枚。場に出される最大5枚のカードから役を作り、勝負！"
             url="/games/holdem"
@@ -64,7 +64,7 @@ const Home = () => (
             url="/games/rummy"
             imgPath="/images/thumbnailSample.png"
             ruleUrl="/rules/rummy"
-          />
+          /> */}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
#83 

# 変更内容
Hold'emとRummyを一時的に非表示にした。
![image](https://user-images.githubusercontent.com/28249208/234929267-c2684cd3-e311-4df6-b5be-a57a17a1084c.png)


# 影響範囲
ゲームへの影響はない。

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
