### PR TITLE
fix: 🐛: #89 chip配列を初期化する

### DIFF
--- a/games/common/scenes/BetScene.ts
+++ b/games/common/scenes/BetScene.ts
@@ -145,6 +145,7 @@ export default class BetScene extends BaseScene {
   private createChips(): void {
     const chipHeight: number =
       Number(this.config.height) / 2;
+    this.#chips = [];
 
     const whiteChip = new Button(
       this,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
#89

# 変更内容
chipの配列をBetScene表示時に初期化するように変更した。結果、画像のように、Chipの配置がずれるバグが解消された。

![image](https://user-images.githubusercontent.com/28249208/235392919-dcdb8f5b-6e9f-4242-b6c3-2b2e02679324.png)

# 影響範囲
特になし。

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
