### PR TITLE
fix: :bug: #96 カード配布時にHouseのPlayを一時停止する

### DIFF
--- a/games/speed/scenes/PlayScene.ts
+++ b/games/speed/scenes/PlayScene.ts
@@ -210,7 +210,20 @@ export default class PlayScene extends Table {
 
   private playHouse(): void {
     if (this.isGameStagnant()) {
+      // HouseのPlayを一時停止する
+      this.housePlayTimeEvent?.remove();
       this.dealLeadCards();
+      // HouseのPlayを再開する
+      this.time.delayedCall(2000, () => {
+        this.housePlayTimeEvent = this.time.addEvent({
+          delay: this.betScene
+            ? (3 - this.betScene.level) * 1500
+            : 4500,
+          callback: this.playHouseTurn,
+          callbackScope: this,
+          loop: true
+        });
+      });
     }
   }
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
#96 

# 変更内容
カード配布時に、HouseのPlayを一時的に停止するように変更した。これにより、カードを補充した瞬間にHouseがカードを出すという挙動を防げる。

# 影響範囲
他のゲームへの影響はない。

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
