### PR TITLE
 fix: 🐛 #110 デッキの初期位置を引数で指定した位置に配置するように修正

### DIFF
--- a/games/blackjack/scenes/PlayScene.ts
+++ b/games/blackjack/scenes/PlayScene.ts
@@ -68,7 +68,7 @@ export default class PlayScene extends Table {
 
     this.resetAndShuffleDeck(
       this.config.width + GAME.CARD.WIDTH,
-      GAME.CARD.HEIGHT
+      -GAME.CARD.HEIGHT
     );
     this.dealInitialCards();
 

--- a/games/common/Factories/tableScene.ts
+++ b/games/common/Factories/tableScene.ts
@@ -82,14 +82,6 @@ export default abstract class Table extends BaseScene {
   ): void {
     this.deck = undefined;
     this.deck = new Deck(this, x ?? 0, y ?? 0);
-    this.deck.cardList.forEach((card) => {
-      Phaser.Display.Align.In.Center(
-        card as Card,
-        this.gameZone as Zone,
-        x ?? 0,
-        y ?? 0
-      );
-    });
     this.deck.shuffle();
   }
 

--- a/games/common/constants/game.ts
+++ b/games/common/constants/game.ts
@@ -56,6 +56,9 @@ const GAME = {
     FLIP_OVER_SOUND_KEY: 'flipOverCard',
     PUT_DOWN_SOUND_KEY: 'putDownCard'
   },
+  DECK: {
+    POKER_HEIGHT: 600
+  },
   COMMON_IMG_ASSETS_PATH: '/game_assets/common/images',
   COMMON_SOUND_ASSETS_PATH: '/game_assets/common/sounds'
 } as const;

--- a/games/poker/scenes/PlayScene.ts
+++ b/games/poker/scenes/PlayScene.ts
@@ -81,7 +81,7 @@ export default class PlayScene extends Table {
     this.createPot();
     this.resetAndShuffleDeck(
       this.config.width / 2,
-      this.config.height / 2 - 600
+      this.config.height / 2 - GAME.DECK.POKER_HEIGHT
     );
     this.createBackButton();
     this.createPlayerNameTexts();
@@ -959,7 +959,7 @@ export default class PlayScene extends Table {
 
     this.resetAndShuffleDeck(
       this.config.width / 2,
-      this.config.height / 2 - 600
+      this.config.height / 2 - GAME.DECK.POKER_HEIGHT
     );
   }
 

--- a/games/poker/scenes/PlayScene.ts
+++ b/games/poker/scenes/PlayScene.ts
@@ -79,7 +79,10 @@ export default class PlayScene extends Table {
   create(): void {
     super.create();
     this.createPot();
-    this.resetAndShuffleDeck(0, -600);
+    this.resetAndShuffleDeck(
+      this.config.width / 2,
+      this.config.height / 2 - 600
+    );
     this.createBackButton();
     this.createPlayerNameTexts();
     this.createPlayerHandZones(
@@ -954,7 +957,10 @@ export default class PlayScene extends Table {
       player.clearHand();
     });
 
-    this.resetAndShuffleDeck(0, -600);
+    this.resetAndShuffleDeck(
+      this.config.width / 2,
+      this.config.height / 2 - 600
+    );
   }
 
   playGameResultSound(result: string): void {


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#110 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
引数で指定したx, y座標の位置へデッキを配置するように修正。
gameZoneへ依存しないようにした。
```ts
  protected resetAndShuffleDeck(
    x?: number,
    y?: number
  ): void {
    this.deck = undefined;
    this.deck = new Deck(this, x ?? 0, y ?? 0);
    this.deck.shuffle();
  }
```


# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
PokerのPlaySceneでの引数を変更した。

```ts
    this.resetAndShuffleDeck(
      this.config.width / 2,
      this.config.height / 2 - 600
    );
```


# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
