### PR TITLE
 feat: ✨ #115 ショーダウン時に敵のカードを開示する。

### DIFF
--- a/games/poker/scenes/PlayScene.ts
+++ b/games/poker/scenes/PlayScene.ts
@@ -688,6 +688,11 @@ export default class PlayScene extends Table {
         );
       });
 
+      console.log(
+        this.players[1].hand,
+        `index: ${playerIndex}`
+      );
+
       this.nextPlayerTurnOnChangeHandRound(0);
     });
   }
@@ -894,6 +899,10 @@ export default class PlayScene extends Table {
       handRanks.push(handRank);
     });
 
+    this.showdownCpuHand();
+    this.cpuBettingStatus?.destroy();
+
+    // 勝敗結果表示
     const resultText = this.add
       .text(
         this.config.width / 2,
@@ -904,21 +913,28 @@ export default class PlayScene extends Table {
       .setOrigin(0.5)
       .setDepth(10);
 
-    this.resetRound();
-
-    this.time.delayedCall(3000, () => {
+    this.time.delayedCall(4000, () => {
       handRanks.forEach((handRank) => {
         handRank.destroy();
       });
       resultText.destroy();
+      this.resetRound();
       this.dealInitialCards();
       // this.createDealerButton(this.playerHandZones[0]);
-      console.log(this.playerBet);
       this.PlayAnte();
     });
 
-    this.time.delayedCall(4000, () => {
+    this.time.delayedCall(5000, () => {
       this.createActionPanel();
+    });
+  }
+
+  private showdownCpuHand(): void {
+    console.log(this.player.hand);
+    this.players[1].hand.forEach((card) => {
+      if (card.isFaceDown) {
+        card.playFlipOverTween();
+      }
     });
   }
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#115 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
Pokerでショーダウン時に、敵のカードを開示するようにした。
![Screenshot from 2023-05-07 21-51-03](https://user-images.githubusercontent.com/66685205/236678962-3bceec9d-cedb-44b8-bc9b-ba332bac14e8.png)


# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

